### PR TITLE
correcting regex for kebab-case

### DIFF
--- a/lib/constants/naming-convention.js
+++ b/lib/constants/naming-convention.js
@@ -22,7 +22,7 @@ const SNAKE_CASE = '+([a-z])*(_+([a-z0-9]))';
 /**
  * @example hello, hello-world
  */
-const KEBAB_CASE = '+([a-z])*(-+([a-z0-9]))';
+const KEBAB_CASE = '+([a-z])+([a-z0-9])*(-+([a-z0-9]))';
 
 /**
  * @example HELLO, HELLO_WORLD

--- a/lib/constants/naming-convention.js
+++ b/lib/constants/naming-convention.js
@@ -22,7 +22,7 @@ const SNAKE_CASE = '+([a-z])*(_+([a-z0-9]))';
 /**
  * @example hello, hello-world
  */
-const KEBAB_CASE = '+([a-z])+([a-z0-9])*(-+([a-z0-9]))';
+const KEBAB_CASE = '+([a-z])*([a-z0-9])*(-+([a-z0-9]))';
 
 /**
  * @example HELLO, HELLO_WORLD


### PR DESCRIPTION
`i18n-test.ts` is a perfectly valid kebab-case filename. But the regex in the plugin was rejecting it.

This also makes me realise, the other regexes are also missing a `0-9` in the first token.

Thanks allot for the plugin.