### PR TITLE
Rule to blacklist / prohibit certain file name patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Then configure the rules you want to use under the rules section.
 - [check-file/filename-naming-convention](docs/rules/filename-naming-convention.md): Enforce a consistent naming pattern for the filename of the specified file
 - [check-file/no-index](docs/rules/no-index.md): A file cannot be named "index"
 - [check-file/folder-naming-convention](docs/rules/folder-naming-convention.md): Enforce a consistent naming pattern for the name of the specified folder
+- [check-file/filename-blacklist](docs/rules/filename-blacklist.md): Blacklist file names by pattern

--- a/docs/rules/filename-blacklist.md
+++ b/docs/rules/filename-blacklist.md
@@ -1,0 +1,33 @@
+# The filename should not be blacklisted (filename-blacklist)
+
+Allows you to blacklist certain file patterns.
+
+## Rule Details
+
+This rule aims to maintain a consistent naming scheme.
+
+### Options
+
+#### naming pattern object
+
+You need to specify a different naming pattern for different file. The plugin will only check files you explicitly selected:
+
+```js
+module.exports = {
+  plugins: [
+    'check-file',
+  ],
+  rules: {
+    'check-file/filename-blacklist': ['error', {
+      '**/*.model.ts': '*.models.ts',
+      '**/*.util.ts': '*.utils.ts',
+    }],
+  },
+};
+```
+
+## Further Reading
+
+- [micromatch](https://github.com/micromatch/micromatch)
+- [glob](https://en.wikipedia.org/wiki/Glob_(programming))
+- [testing glob expression online](https://globster.xyz)

--- a/docs/rules/filename-blacklist.md
+++ b/docs/rules/filename-blacklist.md
@@ -1,16 +1,36 @@
 # The filename should not be blacklisted (filename-blacklist)
 
-Allows you to blacklist certain file patterns.
+Allows you to blacklist certain file name patterns.
 
 ## Rule Details
 
 This rule aims to maintain a consistent naming scheme.
 
+If the rule had been set as follows:
+```js
+...
+'check-file/filename-blacklist': ['error', { '**/*.model.ts': '*.models.ts' }],
+...
+```
+
+Examples of **incorrect** filename with path for this rule:
+```sh
+src/foo.model.ts
+src/bar.model.ts
+```
+
+Examples of **correct** filename with path for this rule:
+```sh
+src/foo.models.ts
+src/bar.models.ts
+```
+
+
 ### Options
 
-#### naming pattern object
+#### blacklist pattern object
 
-You need to specify a different naming pattern for different file. The plugin will only check files you explicitly selected:
+You need to specify a different naming pattern for each filename blacklist. The second pattern is used to hint at the correct file name that should be used instead.
 
 ```js
 module.exports = {

--- a/lib/rules/filename-blacklist.js
+++ b/lib/rules/filename-blacklist.js
@@ -7,7 +7,7 @@
 const { getFilename, getFilePath } = require('../utils/filename');
 const { checkSettings, globPatternValidator } = require('../utils/settings');
 const { getDocUrl } = require('../utils/doc');
-const { matchBlacklistRule } = require('../utils/match');
+const { matchRule } = require('../utils/match');
 
 /**
  * @type {import('eslint').Rule.RuleModule}
@@ -27,9 +27,6 @@ module.exports = {
         additionalProperties: {
           type: 'string',
         },
-      },
-      {
-        type: 'object',
       },
     ],
   },
@@ -63,23 +60,19 @@ module.exports = {
         for (const [blackListPattern, useInsteadPattern] of Object.entries(
           rules
         )) {
-          const matchResult = matchBlacklistRule(filename, blackListPattern);
+          const matchResult = matchRule(filename, blackListPattern);
 
           if (matchResult) {
-            const { path, pattern } = matchResult;
+            const { path } = matchResult;
             let message =
-              'The filename "{{path}}" matches the blacklisted "{{pattern}}" pattern.';
-
-            if (useInsteadPattern) {
-              message += ' Use a pattern like {{ useInsteadPattern }} instead.';
-            }
+              'The filename "{{ path }}" matches the blacklisted "{{ blackListPattern }}" pattern. Use a pattern like "{{ useInsteadPattern }}" instead.';
 
             context.report({
               node,
               message,
               data: {
                 path,
-                pattern,
+                blackListPattern,
                 useInsteadPattern,
               },
             });

--- a/lib/rules/filename-blacklist.js
+++ b/lib/rules/filename-blacklist.js
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview The filename should not be blacklisted.
+ * @author Florian Ehmke
+ */
+'use strict';
+
+const { getFilename, getFilePath } = require('../utils/filename');
+const { checkSettings, globPatternValidator } = require('../utils/settings');
+const { getDocUrl } = require('../utils/doc');
+const { matchBlacklistRule } = require('../utils/match');
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'The filename should not be blacklisted',
+      category: 'Layout & Formatting',
+      recommended: false,
+      url: getDocUrl('filename-blacklist'),
+    },
+    fixable: null,
+    schema: [
+      {
+        additionalProperties: {
+          type: 'string',
+        },
+      },
+      {
+        type: 'object',
+      },
+    ],
+  },
+
+  create(context) {
+    return {
+      Program: (node) => {
+        const rules = context.options[0];
+
+        const invalidPattern = checkSettings(
+          rules,
+          globPatternValidator,
+          globPatternValidator
+        );
+
+        if (invalidPattern) {
+          context.report({
+            node,
+            message:
+              'There is an invalid pattern "{{invalidPattern}}", please check it',
+            data: {
+              invalidPattern,
+            },
+          });
+          return;
+        }
+
+        const filenameWithPath = getFilePath(context);
+        const filename = getFilename(filenameWithPath);
+
+        for (const [blackListPattern, useInsteadPattern] of Object.entries(
+          rules
+        )) {
+          const matchResult = matchBlacklistRule(filename, blackListPattern);
+
+          if (matchResult) {
+            const { path, pattern } = matchResult;
+            let message =
+              'The filename "{{path}}" matches the blacklisted "{{pattern}}" pattern.';
+
+            if (useInsteadPattern) {
+              message += ' Use a pattern like {{ useInsteadPattern }} instead.';
+            }
+
+            context.report({
+              node,
+              message,
+              data: {
+                path,
+                pattern,
+                useInsteadPattern,
+              },
+            });
+            return;
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/utils/match.js
+++ b/lib/utils/match.js
@@ -23,6 +23,8 @@ const matchRule = (
   if (!micromatch.isMatch(filePath, targetFilePathPattern)) {
     return;
   } else if (
+    targetNaming &&
+    targetNamingPattern &&
     micromatch.isMatch(
       targetNaming,
       NAMING_CONVENTION[targetNamingPattern] || targetNamingPattern
@@ -37,17 +39,6 @@ const matchRule = (
   }
 };
 
-const matchBlacklistRule = (filePath, blackListPattern) => {
-  if (!micromatch.isMatch(filePath, blackListPattern)) {
-    return;
-  }
-  return {
-    path: filePath,
-    pattern: blackListPattern,
-  };
-};
-
 module.exports = {
   matchRule,
-  matchBlacklistRule,
 };

--- a/lib/utils/match.js
+++ b/lib/utils/match.js
@@ -37,6 +37,17 @@ const matchRule = (
   }
 };
 
+const matchBlacklistRule = (filePath, blackListPattern) => {
+  if (!micromatch.isMatch(filePath, blackListPattern)) {
+    return;
+  }
+  return {
+    path: filePath,
+    pattern: blackListPattern,
+  };
+};
+
 module.exports = {
   matchRule,
+  matchBlacklistRule,
 };

--- a/tests/lib/rules/filename-blacklist.js
+++ b/tests/lib/rules/filename-blacklist.js
@@ -30,7 +30,7 @@ ruleTester.run('filename-blacklist', rule, {
       errors: [
         {
           message:
-            'The filename "foo.models.ts" matches the blacklisted "*.models.ts" pattern. Use a pattern like *.model.ts instead.',
+            'The filename "foo.models.ts" matches the blacklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
           column: 1,
           line: 1,
         },
@@ -43,7 +43,7 @@ ruleTester.run('filename-blacklist', rule, {
       errors: [
         {
           message:
-            'The filename "foo.utils.ts" matches the blacklisted "*.utils.ts" pattern. Use a pattern like *.util.ts instead.',
+            'The filename "foo.utils.ts" matches the blacklisted "*.utils.ts" pattern. Use a pattern like "*.util.ts" instead.',
           column: 1,
           line: 1,
         },

--- a/tests/lib/rules/filename-blacklist.js
+++ b/tests/lib/rules/filename-blacklist.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview The filename should follow the filename naming convention
+ * @author Florian Ehmke
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/filename-blacklist');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('filename-blacklist', rule, {
+  valid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/foo.model.ts',
+      options: [{ '*.models.ts': '*.model.ts' }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/foo.util‚.ts',
+      options: [{ '*.utils.ts': '*.util.ts' }],
+    },
+  ],
+  invalid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/foo.models.ts',
+      options: [{ '*.models.ts': '*.model.ts' }],
+      errors: [
+        {
+          message:
+            'The filename "foo.models.ts" matches the blacklisted "*.models.ts" pattern. Use a pattern like *.model.ts instead.',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/foo.utils.ts',
+      options: [{ '*.utils.ts': '*.util.ts' }],
+      errors: [
+        {
+          message:
+            'The filename "foo.utils.ts" matches the blacklisted "*.utils.ts" pattern. Use a pattern like *.util.ts instead.',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds a new rule to prohibit certain file name patterns.

I think this is a good addition to this plugin. I often see inconsistent usage of file patterns like the ones used in the tests. Instead of documenting such things I want an eslint rule that takes care of that for me.

Let me know what you think and if I should change something. 