### PR TITLE
refactor: update blacklist to blocklist to remove noninclusive language

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then configure the rules you want to use under the rules section.
         "mocks/*/": "KEBAB_CASE"
       }
     ],
-    "check-file/filename-blacklist": [
+    "check-file/filename-blocklist": [
       "error",
       {
         "**/*.model.ts": "*.models.ts",
@@ -81,7 +81,7 @@ Then configure the rules you want to use under the rules section.
 - [check-file/filename-naming-convention](docs/rules/filename-naming-convention.md): Enforce a consistent naming pattern for the filename of the specified file
 - [check-file/no-index](docs/rules/no-index.md): A file cannot be named "index"
 - [check-file/folder-naming-convention](docs/rules/folder-naming-convention.md): Enforce a consistent naming pattern for the name of the specified folder
-- [check-file/filename-blacklist](docs/rules/filename-blacklist.md): Blacklist file names by pattern
+- [check-file/filename-blocklist](docs/rules/filename-blocklist.md): Blocklist file names by pattern
 
 
 [npm-image]: https://img.shields.io/npm/v/eslint-plugin-check-file.svg

--- a/docs/rules/filename-blocklist.md
+++ b/docs/rules/filename-blocklist.md
@@ -1,6 +1,6 @@
-# The filename should not be blacklisted (filename-blacklist)
+# The filename should be blocklisted (filename-blocklist)
 
-Allows you to blacklist certain file name patterns.
+Allows you to blocklist certain file name patterns.
 
 ## Rule Details
 
@@ -9,7 +9,7 @@ This rule aims to maintain a consistent naming scheme.
 If the rule had been set as follows:
 ```js
 ...
-'check-file/filename-blacklist': ['error', { '**/*.model.ts': '*.models.ts' }],
+'check-file/filename-blocklist': ['error', { '**/*.model.ts': '*.models.ts' }],
 ...
 ```
 
@@ -28,9 +28,9 @@ src/bar.models.ts
 
 ### Options
 
-#### blacklist pattern object
+#### blocklist pattern object
 
-You need to specify a different naming pattern for each filename blacklist. The second pattern is used to hint at the correct file name that should be used instead.
+You need to specify a different naming pattern for each filename blocklist. The second pattern is used to hint at the correct file name that should be used instead.
 
 ```js
 module.exports = {
@@ -38,7 +38,7 @@ module.exports = {
     'check-file',
   ],
   rules: {
-    'check-file/filename-blacklist': ['error', {
+    'check-file/filename-blocklist': ['error', {
       '**/*.model.ts': '*.models.ts',
       '**/*.util.ts': '*.utils.ts',
     }],

--- a/lib/rules/filename-blocklist.js
+++ b/lib/rules/filename-blocklist.js
@@ -1,5 +1,5 @@
 /**
- * @file The filename should not be blacklisted.
+ * @file The filename should be blocklisted.
  * @author Florian Ehmke
  */
 'use strict';
@@ -17,10 +17,10 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'The filename should not be blacklisted',
+      description: 'The filename should be blocklisted',
       category: 'Layout & Formatting',
       recommended: false,
-      url: getDocUrl('filename-blacklist'),
+      url: getDocUrl('filename-blocklist'),
     },
     fixable: null,
     schema: [
@@ -58,10 +58,10 @@ module.exports = {
         const filenameWithPath = getFilePath(context);
         const filename = getFilename(filenameWithPath);
 
-        for (const [blackListPattern, useInsteadPattern] of Object.entries(
+        for (const [blockListPattern, useInsteadPattern] of Object.entries(
           rules
         )) {
-          const matchResult = matchRule(filename, blackListPattern);
+          const matchResult = matchRule(filename, blockListPattern);
 
           if (matchResult) {
             const { path } = matchResult;
@@ -69,10 +69,10 @@ module.exports = {
             context.report({
               node,
               message:
-                'The filename "{{ path }}" matches the blacklisted "{{ blackListPattern }}" pattern. Use a pattern like "{{ useInsteadPattern }}" instead.',
+                'The filename "{{ path }}" matches the blocklisted "{{ blockListPattern }}" pattern. Use a pattern like "{{ useInsteadPattern }}" instead.',
               data: {
                 path,
-                blackListPattern,
+                blockListPattern,
                 useInsteadPattern,
               },
             });

--- a/tests/lib/rules/filename-blocklist.posix.js
+++ b/tests/lib/rules/filename-blocklist.posix.js
@@ -1,6 +1,6 @@
 /**
- * @file The filename should not be blacklisted
- * @author Duke Luo
+ * @file The filename should be blocklisted
+ * @author Florian Ehmke, Duke Luo
  */
 'use strict';
 
@@ -8,37 +8,41 @@ const path = require('path');
 const proxyquire = require('proxyquire');
 const RuleTester = require('eslint').RuleTester;
 
-const rule = proxyquire('../../../lib/rules/filename-blacklist', {
-  path: { ...path.win32, '@global': true },
+const rule = proxyquire('../../../lib/rules/filename-blocklist', {
+  path: { ...path.posix, '@global': true },
 });
 const ruleTester = new RuleTester();
 
 ruleTester.run(
-  "filename-blacklist with option on Windows: [{ '*.models.ts': '*.model.ts' }]",
+  "filename-blocklist with option: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }]",
   rule,
   {
     valid: [
       {
         code: "var foo = 'bar';",
-        filename: 'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.model.ts',
-        options: [{ '*.models.ts': '*.model.ts' }],
+        filename: 'src/foo.model.ts',
+        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
       },
       {
         code: "var foo = 'bar';",
-        filename: 'src\\foo.model.ts',
-        options: [{ '*.models.ts': '*.model.ts' }],
+        filename: 'src/foo.util.ts',
+        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/foo.apis.ts',
+        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
       },
     ],
     invalid: [
       {
         code: "var foo = 'bar';",
-        filename:
-          'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.models.ts',
-        options: [{ '*.models.ts': '*.model.ts' }],
+        filename: 'src/foo.models.ts',
+        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blacklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -46,12 +50,12 @@ ruleTester.run(
       },
       {
         code: "var foo = 'bar';",
-        filename: 'src\\foo.models.ts',
-        options: [{ '*.models.ts': '*.model.ts' }],
+        filename: 'src/foo.utils.ts',
+        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blacklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
+              'The filename "foo.utils.ts" matches the blocklisted "*.utils.ts" pattern. Use a pattern like "*.util.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -62,7 +66,7 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  "filename-blacklist with option on Windows: [{ '*.models.ts': 'FOO' }]",
+  "filename-blocklist with option: [{ '*.models.ts': 'FOO' }]",
   rule,
   {
     valid: [],
@@ -70,7 +74,7 @@ ruleTester.run(
     invalid: [
       {
         code: "var foo = 'bar';",
-        filename: 'src\\foo.models.ts',
+        filename: 'src/foo.models.ts',
         options: [{ '*.models.ts': 'FOO' }],
         errors: [
           {
@@ -85,7 +89,7 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  "filename-blacklist with option on Windows: [{ 'models.ts': '*.model.ts' }]",
+  "filename-blocklist with option: [{ 'models.ts': '*.model.ts' }]",
   rule,
   {
     valid: [],
@@ -93,7 +97,7 @@ ruleTester.run(
     invalid: [
       {
         code: "var foo = 'bar';",
-        filename: 'src\\foo.models.ts',
+        filename: 'src/foo.models.ts',
         options: [{ 'models.ts': '*.model.ts' }],
         errors: [
           {

--- a/tests/lib/rules/filename-blocklist.windows.js
+++ b/tests/lib/rules/filename-blocklist.windows.js
@@ -1,6 +1,6 @@
 /**
- * @file The filename should not be blacklisted
- * @author Florian Ehmke, Duke Luo
+ * @file The filename should be blocklisted
+ * @author Duke Luo
  */
 'use strict';
 
@@ -8,41 +8,37 @@ const path = require('path');
 const proxyquire = require('proxyquire');
 const RuleTester = require('eslint').RuleTester;
 
-const rule = proxyquire('../../../lib/rules/filename-blacklist', {
-  path: { ...path.posix, '@global': true },
+const rule = proxyquire('../../../lib/rules/filename-blocklist', {
+  path: { ...path.win32, '@global': true },
 });
 const ruleTester = new RuleTester();
 
 ruleTester.run(
-  "filename-blacklist with option: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }]",
+  "filename-blocklist with option on Windows: [{ '*.models.ts': '*.model.ts' }]",
   rule,
   {
     valid: [
       {
         code: "var foo = 'bar';",
-        filename: 'src/foo.model.ts',
-        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
+        filename: 'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.model.ts',
+        options: [{ '*.models.ts': '*.model.ts' }],
       },
       {
         code: "var foo = 'bar';",
-        filename: 'src/foo.util.ts',
-        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
-      },
-      {
-        code: "var foo = 'bar';",
-        filename: 'src/foo.apis.ts',
-        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
+        filename: 'src\\foo.model.ts',
+        options: [{ '*.models.ts': '*.model.ts' }],
       },
     ],
     invalid: [
       {
         code: "var foo = 'bar';",
-        filename: 'src/foo.models.ts',
-        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
+        filename:
+          'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.models.ts',
+        options: [{ '*.models.ts': '*.model.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blacklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -50,12 +46,12 @@ ruleTester.run(
       },
       {
         code: "var foo = 'bar';",
-        filename: 'src/foo.utils.ts',
-        options: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }],
+        filename: 'src\\foo.models.ts',
+        options: [{ '*.models.ts': '*.model.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.utils.ts" matches the blacklisted "*.utils.ts" pattern. Use a pattern like "*.util.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -66,7 +62,7 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  "filename-blacklist with option: [{ '*.models.ts': 'FOO' }]",
+  "filename-blocklist with option on Windows: [{ '*.models.ts': 'FOO' }]",
   rule,
   {
     valid: [],
@@ -74,7 +70,7 @@ ruleTester.run(
     invalid: [
       {
         code: "var foo = 'bar';",
-        filename: 'src/foo.models.ts',
+        filename: 'src\\foo.models.ts',
         options: [{ '*.models.ts': 'FOO' }],
         errors: [
           {
@@ -89,7 +85,7 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  "filename-blacklist with option: [{ 'models.ts': '*.model.ts' }]",
+  "filename-blocklist with option on Windows: [{ 'models.ts': '*.model.ts' }]",
   rule,
   {
     valid: [],
@@ -97,7 +93,7 @@ ruleTester.run(
     invalid: [
       {
         code: "var foo = 'bar';",
-        filename: 'src/foo.models.ts',
+        filename: 'src\\foo.models.ts',
         options: [{ 'models.ts': '*.model.ts' }],
         errors: [
           {


### PR DESCRIPTION
This PR updates the 'blacklist' term to 'blocklist' to use more inclusive language.

I also updated the file description: `The filename should not be blocklisted` to `The filename should be blocklisted`. Having the `not` seemed incorrect based on what the rule does.

Happy to use another term if you think `blocklist` doesn't work.