### PR TITLE
fix: update filename-blocklist to check filename path

### DIFF
--- a/lib/rules/filename-blocklist.js
+++ b/lib/rules/filename-blocklist.js
@@ -61,7 +61,9 @@ module.exports = {
         for (const [blockListPattern, useInsteadPattern] of Object.entries(
           rules
         )) {
-          const matchResult = matchRule(filenameWithPath, blockListPattern);
+          const matchResult =
+            matchRule(filenameWithPath, blockListPattern) ||
+            matchRule(filename, blockListPattern);
 
           if (matchResult) {
             context.report({

--- a/tests/lib/rules/filename-blocklist.posix.js
+++ b/tests/lib/rules/filename-blocklist.posix.js
@@ -14,7 +14,7 @@ const rule = proxyquire('../../../lib/rules/filename-blocklist', {
 const ruleTester = new RuleTester();
 
 ruleTester.run(
-  "filename-blocklist with option: [{ '**/*.models.ts': '**/*.model.ts', '**/*.utils.ts': '**/*.util.ts' }]",
+  "filename-blocklist with option: [{ '*.models.ts': '*.model.ts', '*.utils.ts': '*.util.ts' }]",
   rule,
   {
     valid: [
@@ -23,8 +23,8 @@ ruleTester.run(
         filename: 'src/foo.model.ts',
         options: [
           {
-            '**/*.models.ts': '**/*.model.ts',
-            '**/*.utils.ts': '**/*.util.ts',
+            '*.models.ts': '*.model.ts',
+            '*.utils.ts': '*.util.ts',
           },
         ],
       },
@@ -33,8 +33,8 @@ ruleTester.run(
         filename: 'src/foo.util.ts',
         options: [
           {
-            '**/*.models.ts': '**/*.model.ts',
-            '**/*.utils.ts': '**/*.util.ts',
+            '*.models.ts': '*.model.ts',
+            '*.utils.ts': '*.util.ts',
           },
         ],
       },
@@ -43,8 +43,8 @@ ruleTester.run(
         filename: 'src/foo.apis.ts',
         options: [
           {
-            '**/*.models.ts': '**/*.model.ts',
-            '**/*.utils.ts': '**/*.util.ts',
+            '*.models.ts': '*.model.ts',
+            '*.utils.ts': '*.util.ts',
           },
         ],
       },
@@ -55,14 +55,14 @@ ruleTester.run(
         filename: 'src/foo.models.ts',
         options: [
           {
-            '**/*.models.ts': '**/*.model.ts',
-            '**/*.utils.ts': '**/*.util.ts',
+            '*.models.ts': '*.model.ts',
+            '*.utils.ts': '*.util.ts',
           },
         ],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blocklisted "**/*.models.ts" pattern. Use a pattern like "**/*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -73,14 +73,14 @@ ruleTester.run(
         filename: 'src/foo.utils.ts',
         options: [
           {
-            '**/*.models.ts': '**/*.model.ts',
-            '**/*.utils.ts': '**/*.util.ts',
+            '*.models.ts': '*.model.ts',
+            '*.utils.ts': '*.util.ts',
           },
         ],
         errors: [
           {
             message:
-              'The filename "foo.utils.ts" matches the blocklisted "**/*.utils.ts" pattern. Use a pattern like "**/*.util.ts" instead.',
+              'The filename "foo.utils.ts" matches the blocklisted "*.utils.ts" pattern. Use a pattern like "*.util.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -91,7 +91,7 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  "filename-blocklist with option: [{ 'src/**/*.models.ts': 'src/**/*.model.ts', 'src/**/*.utils.ts': 'src/**/*.util.ts' }]",
+  "filename-blocklist with option: [{ 'src/*.models.ts': '*.model.ts', 'src/*.utils.ts': '*.util.ts' }]",
   rule,
   {
     valid: [
@@ -100,8 +100,8 @@ ruleTester.run(
         filename: 'not-src/foo.model.ts',
         options: [
           {
-            'src/**/*.models.ts': 'src/**/*.model.ts',
-            'src/**/*.utils.ts': 'src/**/*.util.ts',
+            'src/*.models.ts': '*.model.ts',
+            'src/*.utils.ts': '*.util.ts',
           },
         ],
       },
@@ -110,8 +110,8 @@ ruleTester.run(
         filename: 'not-src/foo.util.ts',
         options: [
           {
-            'src/**/*.models.ts': 'src/**/*.model.ts',
-            'src/**/*.utils.ts': 'src/**/*.util.ts',
+            'src/*.models.ts': '*.model.ts',
+            'src/*.utils.ts': '*.util.ts',
           },
         ],
       },
@@ -120,8 +120,8 @@ ruleTester.run(
         filename: 'not-src/foo.apis.ts',
         options: [
           {
-            'src/**/*.models.ts': 'src/**/*.model.ts',
-            'src/**/*.utils.ts': 'src/**/*.util.ts',
+            'src/*.models.ts': '*.model.ts',
+            'src/*.utils.ts': '*.util.ts',
           },
         ],
       },
@@ -132,14 +132,14 @@ ruleTester.run(
         filename: 'src/foo.models.ts',
         options: [
           {
-            'src/**/*.models.ts': 'src/**/*.model.ts',
-            'src/**/*.utils.ts': 'src/**/*.util.ts',
+            'src/*.models.ts': '*.model.ts',
+            'src/*.utils.ts': '*.util.ts',
           },
         ],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blocklisted "src/**/*.models.ts" pattern. Use a pattern like "src/**/*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "src/*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -150,14 +150,14 @@ ruleTester.run(
         filename: 'src/foo.utils.ts',
         options: [
           {
-            'src/**/*.models.ts': 'src/**/*.model.ts',
-            'src/**/*.utils.ts': 'src/**/*.util.ts',
+            'src/*.models.ts': '*.model.ts',
+            'src/*.utils.ts': '*.util.ts',
           },
         ],
         errors: [
           {
             message:
-              'The filename "foo.utils.ts" matches the blocklisted "src/**/*.utils.ts" pattern. Use a pattern like "src/**/*.util.ts" instead.',
+              'The filename "foo.utils.ts" matches the blocklisted "src/*.utils.ts" pattern. Use a pattern like "*.util.ts" instead.',
             column: 1,
             line: 1,
           },

--- a/tests/lib/rules/filename-blocklist.windows.js
+++ b/tests/lib/rules/filename-blocklist.windows.js
@@ -14,19 +14,19 @@ const rule = proxyquire('../../../lib/rules/filename-blocklist', {
 const ruleTester = new RuleTester();
 
 ruleTester.run(
-  "filename-blocklist with option on Windows: [{ '**/*.models.ts': '**/*.model.ts' }]",
+  "filename-blocklist with option on Windows: [{ '*.models.ts': '*.model.ts' }]",
   rule,
   {
     valid: [
       {
         code: "var foo = 'bar';",
         filename: 'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.model.ts',
-        options: [{ '**/*.models.ts': '**/*.model.ts' }],
+        options: [{ '*.models.ts': '*.model.ts' }],
       },
       {
         code: "var foo = 'bar';",
         filename: 'src\\foo.model.ts',
-        options: [{ '**/*.models.ts': '**/*.model.ts' }],
+        options: [{ '*.models.ts': '*.model.ts' }],
       },
     ],
     invalid: [
@@ -34,11 +34,11 @@ ruleTester.run(
         code: "var foo = 'bar';",
         filename:
           'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.models.ts',
-        options: [{ '**/*.models.ts': '**/*.model.ts' }],
+        options: [{ '*.models.ts': '*.model.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blocklisted "**/*.models.ts" pattern. Use a pattern like "**/*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -47,11 +47,11 @@ ruleTester.run(
       {
         code: "var foo = 'bar';",
         filename: 'src\\foo.models.ts',
-        options: [{ '**/*.models.ts': '**/*.model.ts' }],
+        options: [{ '*.models.ts': '*.model.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blocklisted "**/*.models.ts" pattern. Use a pattern like "**/*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },
@@ -62,30 +62,30 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  "filename-blocklist with option on Windows: [{ 'src/**/*.models.ts': 'src/**/*.model.ts' }]",
+  "filename-blocklist with option on Windows: [{ 'src/*.models.ts': '*.model.ts' }]",
   rule,
   {
     valid: [
       {
         code: "var foo = 'bar';",
         filename: 'C:\\Users\\Administrator\\Downloads\\wai\\src\\foo.model.ts',
-        options: [{ 'src/**/*.models.ts': 'src/**/*.model.ts' }],
+        options: [{ 'src/*.models.ts': '*.model.ts' }],
       },
       {
         code: "var foo = 'bar';",
         filename: 'src\\foo.model.ts',
-        options: [{ 'src/**/*.models.ts': 'src/**/*.model.ts' }],
+        options: [{ 'src/*.models.ts': '*.model.ts' }],
       },
     ],
     invalid: [
       {
         code: "var foo = 'bar';",
         filename: 'src\\foo.models.ts',
-        options: [{ 'src/**/*.models.ts': 'src/**/*.model.ts' }],
+        options: [{ 'src/*.models.ts': '*.model.ts' }],
         errors: [
           {
             message:
-              'The filename "foo.models.ts" matches the blocklisted "src/**/*.models.ts" pattern. Use a pattern like "src/**/*.model.ts" instead.',
+              'The filename "foo.models.ts" matches the blocklisted "src/*.models.ts" pattern. Use a pattern like "*.model.ts" instead.',
             column: 1,
             line: 1,
           },


### PR DESCRIPTION
While working with the `filename-blocklist` rule, I noticed my globs were not working properly when trying to pick files in specific folders. I then noticed that the rule was only checking the filename itself instead of the full path.

I made this update to check the full path instead of just the filename and added a few tests.

I also kept the rule message to just the filename so the message doesn't become too verbose with long paths.

I'm open to approaching this change differently, via a new rule option perhaps, as well if there is a desire not to introduce another breaking change to the rule.

Let me know your thoughts.