### PR TITLE
feat: allow option for non-glob values for filename-blocklist

### DIFF
--- a/docs/rules/filename-blocklist.md
+++ b/docs/rules/filename-blocklist.md
@@ -54,6 +54,29 @@ module.exports = {
 };
 ```
 
+An optional "nonGlobSuggestion" argument can be passed that allows the blocklist reason to be any string, instead of a strict glob pattern
+
+```js
+module.exports = {
+  plugins: [
+    'check-file',
+  ],
+  rules: {
+    'check-file/filename-blocklist': ['error', {
+      '**/*.model.ts': 'see the repo rules at http://some/example.com',
+      '**/*.util.ts': 'for a non glob related reason',
+    },
+      { nonGlobSuggestion: true, }
+    ],
+  },
+};
+```
+
+These rules would produce errors that look like:
+1. 'The filename "model.ts" matches the blocklisted "**/*.model.ts" pattern,  this is not allowed see the repo rules at http://some/example.com'
+2. 'The filename "util.ts" matches the blocklisted "**/*.util.ts" pattern,  this is not allowed for a non glob related reason'
+
+
 ## Further Reading
 
 - [micromatch](https://github.com/micromatch/micromatch)

--- a/lib/constants/message.js
+++ b/lib/constants/message.js
@@ -16,7 +16,7 @@ export const FILENAME_BLOCKLIST_ERROR_MESSAGE =
   'The filename "{{ filename }}" matches the blocklisted "{{ blockListPattern }}" pattern, use a pattern like "{{ suggestion }}" instead';
 
 export const FILENAME_BLOCKLIST_NON_GLOB_ERROR_MESSAGE =
-  'The filename "{{ filename }}" matches the blocklisted "{{ blockListPattern }}" pattern, this is not allowed because "{{ suggestion }}"';
+  'The filename "{{ filename }}" matches the blocklisted "{{ blockListPattern }}" pattern, this is not allowed {{ suggestion }}';
 
 export const FILENAME_NAMING_CONVENTION_ERROR_MESSAGE =
   'The filename "{{ filename }}" does not match the "{{ originalNamingPattern }}" pattern';

--- a/lib/constants/message.js
+++ b/lib/constants/message.js
@@ -13,7 +13,10 @@ export const PREFINED_MATCH_SYNTAX_ERROR_MESSAGE =
   'The prefined match "{{ namingPattern }}" is not found in the pattern "{{ filenamePattern }}", please double-check it and try again';
 
 export const FILENAME_BLOCKLIST_ERROR_MESSAGE =
-  'The filename "{{ filename }}" matches the blocklisted "{{ blockListPattern }}" pattern, use a pattern like "{{ useInsteadPattern }}" instead';
+  'The filename "{{ filename }}" matches the blocklisted "{{ blockListPattern }}" pattern, use a pattern like "{{ suggestion }}" instead';
+
+export const FILENAME_BLOCKLIST_NON_GLOB_ERROR_MESSAGE =
+  'The filename "{{ filename }}" matches the blocklisted "{{ blockListPattern }}" pattern, this is not allowed because "{{ suggestion }}"';
 
 export const FILENAME_NAMING_CONVENTION_ERROR_MESSAGE =
   'The filename "{{ filename }}" does not match the "{{ originalNamingPattern }}" pattern';

--- a/lib/rules/filename-blocklist.js
+++ b/lib/rules/filename-blocklist.js
@@ -15,7 +15,6 @@ import { matchRule } from '../utils/rule.js';
 import {
   validateNamingPatternObject,
   globPatternValidator,
-  stringResponseValidator,
 } from '../utils/validation.js';
 
 /**
@@ -38,8 +37,9 @@ export default {
         },
       },
       {
-        stringResponse: {
-          type: 'boolean',
+        type: 'object',
+        properties: {
+          nonGlobSuggestion: { type: 'boolean' },
         },
       },
     ],
@@ -55,11 +55,13 @@ export default {
     return {
       Program: (node) => {
         const rules = context.options[0];
-        const stringResponse = context.options[1];
+        const { nonGlobSuggestion } = context.options[1] || {
+          nonGlobSuggestion: false,
+        };
         const error = validateNamingPatternObject(
           rules,
           globPatternValidator,
-          stringResponse ? stringResponseValidator : globPatternValidator
+          nonGlobSuggestion ? () => true : globPatternValidator
         );
 
         if (error) {
@@ -91,7 +93,7 @@ export default {
           if (matchResult) {
             context.report({
               node,
-              messageId: stringResponse ? 'noMatchWithNonGlob' : 'noMatch',
+              messageId: nonGlobSuggestion ? 'noMatchWithNonGlob' : 'noMatch',
               data: {
                 filename,
                 blockListPattern,

--- a/lib/rules/filename-blocklist.js
+++ b/lib/rules/filename-blocklist.js
@@ -5,6 +5,7 @@
 
 import {
   FILENAME_BLOCKLIST_ERROR_MESSAGE,
+  FILENAME_BLOCKLIST_NON_GLOB_ERROR_MESSAGE,
   NAMING_PATTERN_OBJECT_ERROR_MESSAGE,
   PATTERN_ERROR_MESSAGE,
 } from '../constants/message.js';
@@ -14,6 +15,7 @@ import { matchRule } from '../utils/rule.js';
 import {
   validateNamingPatternObject,
   globPatternValidator,
+  stringResponseValidator,
 } from '../utils/validation.js';
 
 /**
@@ -35,11 +37,17 @@ export default {
           type: 'string',
         },
       },
+      {
+        stringResponse: {
+          type: 'boolean',
+        },
+      },
     ],
     messages: {
       invalidObject: NAMING_PATTERN_OBJECT_ERROR_MESSAGE,
       invalidPattern: PATTERN_ERROR_MESSAGE,
       noMatch: FILENAME_BLOCKLIST_ERROR_MESSAGE,
+      noMatchWithNonGlob: FILENAME_BLOCKLIST_NON_GLOB_ERROR_MESSAGE,
     },
   },
 
@@ -47,10 +55,11 @@ export default {
     return {
       Program: (node) => {
         const rules = context.options[0];
+        const stringResponse = context.options[1];
         const error = validateNamingPatternObject(
           rules,
           globPatternValidator,
-          globPatternValidator
+          stringResponse ? stringResponseValidator : globPatternValidator
         );
 
         if (error) {
@@ -67,9 +76,10 @@ export default {
         const filenameWithPath = getFilePath(context);
         const filename = getFilename(filenameWithPath);
 
-        for (const [blockListPattern, useInsteadPattern] of Object.entries(
-          rules
-        )) {
+        for (const [
+          blockListPattern,
+          useInsteadPatternOrString,
+        ] of Object.entries(rules)) {
           const matchResult =
             matchRule(filenameWithPath, blockListPattern) ||
             // TODO: remove this in next major version
@@ -81,11 +91,11 @@ export default {
           if (matchResult) {
             context.report({
               node,
-              messageId: 'noMatch',
+              messageId: stringResponse ? 'noMatchWithNonGlob' : 'noMatch',
               data: {
                 filename,
                 blockListPattern,
-                useInsteadPattern,
+                suggestion: useInsteadPatternOrString,
               },
             });
             return;

--- a/lib/utils/validation.js
+++ b/lib/utils/validation.js
@@ -63,12 +63,6 @@ const nextJsNamingPatternValidator = (namingPattern) =>
 export const globPatternValidator = isGlob;
 
 /**
- * @returns {boolean} true if reason is a string
- * @param {any}  reason an arbitrary reason for banning a file naming pattern that isn't a glob pattern
- */
-export const stringResponseValidator = (reason) => typeof reason === 'string';
-
-/**
  * @returns {boolean} true if pattern is a valid filename naming pattern
  * @param {string} namingPattern pattern string
  */

--- a/lib/utils/validation.js
+++ b/lib/utils/validation.js
@@ -63,6 +63,12 @@ const nextJsNamingPatternValidator = (namingPattern) =>
 export const globPatternValidator = isGlob;
 
 /**
+ * @returns {boolean} true if reason is a string
+ * @param {any}  reason an arbitrary reason for banning a file naming pattern that isn't a glob pattern
+ */
+export const stringResponseValidator = (reason) => typeof reason === 'string';
+
+/**
  * @returns {boolean} true if pattern is a valid filename naming pattern
  * @param {string} namingPattern pattern string
  */

--- a/tests/lib/rules/filename-blocklist.posix.js
+++ b/tests/lib/rules/filename-blocklist.posix.js
@@ -238,7 +238,7 @@ ruleTester.run('filename-blocklist with option: []', rule, {
 });
 
 ruleTester.run(
-  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, true]",
+  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true }]",
   rule,
   {
     valid: [
@@ -253,16 +253,6 @@ ruleTester.run(
         ],
       },
     ],
-
-    invalid: [],
-  }
-);
-
-ruleTester.run(
-  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true, }]",
-  rule,
-  {
-    valid: [],
 
     invalid: [
       {

--- a/tests/lib/rules/filename-blocklist.posix.js
+++ b/tests/lib/rules/filename-blocklist.posix.js
@@ -238,7 +238,7 @@ ruleTester.run('filename-blocklist with option: []', rule, {
 });
 
 ruleTester.run(
-  "filename-blocklist with option: [{'*.models.ts': 'Some Non Glob reason'}, true]",
+  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, true]",
   rule,
   {
     valid: [
@@ -247,13 +247,42 @@ ruleTester.run(
         filename: 'src/foo.apis.ts',
         options: [
           {
-            '*.models.ts': 'Some Non Glob reason',
+            '*.models.ts': 'for some Non Glob related reason',
           },
-          true,
+          { nonGlobSuggestion: true },
         ],
       },
     ],
 
     invalid: [],
+  }
+);
+
+ruleTester.run(
+  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true, }]",
+  rule,
+  {
+    valid: [],
+
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/foo.models.ts',
+        options: [
+          {
+            '*.models.ts': 'for some Non Glob related reason',
+          },
+          { nonGlobSuggestion: true },
+        ],
+        errors: [
+          {
+            message:
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern, this is not allowed for some Non Glob related reason',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
   }
 );

--- a/tests/lib/rules/filename-blocklist.posix.js
+++ b/tests/lib/rules/filename-blocklist.posix.js
@@ -236,3 +236,24 @@ ruleTester.run('filename-blocklist with option: []', rule, {
     },
   ],
 });
+
+ruleTester.run(
+  "filename-blocklist with option: [{'*.models.ts': 'Some Non Glob reason'}, true]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/foo.apis.ts',
+        options: [
+          {
+            '*.models.ts': 'Some Non Glob reason',
+          },
+          true,
+        ],
+      },
+    ],
+
+    invalid: [],
+  }
+);

--- a/tests/lib/rules/filename-blocklist.windows.js
+++ b/tests/lib/rules/filename-blocklist.windows.js
@@ -164,3 +164,51 @@ ruleTester.run('filename-blocklist with option on Windows: []', rule, {
     },
   ],
 });
+
+ruleTester.run(
+  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true, }]  on Windows: []",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\foo.apis.ts',
+        options: [
+          {
+            '*.models.ts': 'for some Non Glob related reason',
+          },
+          { nonGlobSuggestion: true },
+        ],
+      },
+    ],
+
+    invalid: [],
+  }
+);
+
+ruleTester.run(
+  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true, }]  on Windows: []",
+  rule,
+  {
+    valid: [],
+
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\foo.models.ts',
+        options: [
+          { '*.models.ts': 'for some Non Glob related reason' },
+          { nonGlobSuggestion: true },
+        ],
+        errors: [
+          {
+            message:
+              'The filename "foo.models.ts" matches the blocklisted "*.models.ts" pattern, this is not allowed for some Non Glob related reason',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);

--- a/tests/lib/rules/filename-blocklist.windows.js
+++ b/tests/lib/rules/filename-blocklist.windows.js
@@ -166,7 +166,7 @@ ruleTester.run('filename-blocklist with option on Windows: []', rule, {
 });
 
 ruleTester.run(
-  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true, }]  on Windows: []",
+  "filename-blocklist with option on Windows: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true }]",
   rule,
   {
     valid: [
@@ -181,16 +181,6 @@ ruleTester.run(
         ],
       },
     ],
-
-    invalid: [],
-  }
-);
-
-ruleTester.run(
-  "filename-blocklist with option: [{'*.models.ts': 'for some Non Glob related reason'}, { nonGlobSuggestion: true, }]  on Windows: []",
-  rule,
-  {
-    valid: [],
 
     invalid: [
       {


### PR DESCRIPTION
This PR allows an new optional argument in the shema for  the filename blocklist "stringResponse". This allows repos to deny a filenaming schema with an arbitrary reason (say a url for more info) rather than simply a strict globbing pattern.  

new pattern:
```
{
        code: "var foo = 'bar';",
        filename: 'src/foo.models.ts',
        options: [
          {
            '*.models.ts': 'it is a generic naming convention. Please see http://someExample.com for our repo's rules and naming suggestions ',
          },
          true, //optional argument that allows the value string to not be checked as a globbing pattern
        ],
      },
```

response
```
$The filename "foo.models.ts" matches the blocklisted ".models.ts" pattern, this is not allowed because it is a generic naming convention. Please see http://someExample.com for our repo's rules and naming suggestions 
```