### PR TITLE
feat: add support to include multiple folder patterns for the no-index rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "check-file/no-index": "error",
+    "check-file/no-index": [
+      "error",
+      ["src/components/**", "src/utils/**"]
+    ],
     "check-file/filename-blocklist": [
       "error",
       {

--- a/lib/rules/no-index.js
+++ b/lib/rules/no-index.js
@@ -3,9 +3,20 @@
  * @author Huan Luo
  */
 
-import { NO_INDEX_ERROR_MESSAGE } from '../constants/message.js';
+import micromatch from 'micromatch';
+import {
+  NO_INDEX_ERROR_MESSAGE,
+  PATTERN_ERROR_MESSAGE,
+} from '../constants/message.js';
 import { getDocUrl } from '../utils/doc.js';
-import { getBasename, getFilePath, getFilename } from '../utils/filename.js';
+import {
+  getBasename,
+  getFilePath,
+  getFilename,
+  getFolderPath,
+} from '../utils/filename.js';
+import { isEmpty, isNil } from '../utils/utility.js';
+import { globPatternValidator } from '../utils/validation.js';
 
 /**
  * @type {import('eslint').Rule.RuleModule}
@@ -24,29 +35,59 @@ export default {
       {
         type: 'object',
         properties: {
+          folderPaths: { type: 'array' },
           ignoreMiddleExtensions: { type: 'boolean' },
         },
       },
     ],
     messages: {
       noIndex: NO_INDEX_ERROR_MESSAGE,
+      invalidPattern: PATTERN_ERROR_MESSAGE,
     },
   },
 
   create(context) {
     return {
       Program: (node) => {
-        const { ignoreMiddleExtensions } = context.options[0] || {};
+        const rules = context.options[0] || {};
+        const folderPaths = rules.folderPaths;
         const filenameWithPath = getFilePath(context);
+        const folderPath = getFolderPath(filenameWithPath);
         const filename = getFilename(filenameWithPath);
-        const basename = getBasename(filename, ignoreMiddleExtensions);
+        const basename = getBasename(filename, rules.ignoreMiddleExtensions);
 
-        if (basename === 'index') {
-          context.report({
-            node,
-            messageId: 'noIndex',
-          });
+        if (isNil(folderPaths) || isEmpty(folderPaths)) {
+          if (basename === 'index') {
+            context.report({
+              node,
+              messageId: 'noIndex',
+            });
+          }
           return;
+        }
+
+        for (const folderPattern of folderPaths) {
+          if (!globPatternValidator(folderPattern)) {
+            context.report({
+              node,
+              messageId: 'invalidPattern',
+              data: {
+                value: folderPattern,
+              },
+            });
+            continue;
+          }
+
+          if (
+            micromatch.isMatch(folderPath, folderPattern, { contains: true }) &&
+            basename === 'index'
+          ) {
+            context.report({
+              node,
+              messageId: 'noIndex',
+            });
+            continue;
+          }
         }
       },
     };

--- a/tests/lib/rules/no-index.posix.js
+++ b/tests/lib/rules/no-index.posix.js
@@ -131,3 +131,472 @@ ruleTester.run(
     ],
   }
 );
+
+ruleTester.run("no-index with option: [{ folderPaths: ['*'] }]", rule, {
+  valid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/components/login.jsx',
+      options: [{ folderPaths: ['*'] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/utils/calculatePrice.js',
+      options: [{ folderPaths: ['*'] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/utils/index.config.js',
+      options: [{ folderPaths: ['*'] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'index.config.js',
+      options: [{ folderPaths: ['*'] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/components/index.jsx',
+      options: [{ folderPaths: ['*'] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/utils/index.js',
+      options: [{ folderPaths: ['*'] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'index.js',
+      options: [{ folderPaths: ['*'] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('no-index with option: [{ folderPaths: [] }]', rule, {
+  valid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/components/login.jsx',
+      options: [{ folderPaths: [] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/utils/calculatePrice.js',
+      options: [{ folderPaths: [] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/utils/index.config.js',
+      options: [{ folderPaths: [] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'index.config.js',
+      options: [{ folderPaths: [] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/components/index.jsx',
+      options: [{ folderPaths: [] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src/utils/index.js',
+      options: [{ folderPaths: [] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'index.js',
+      options: [{ folderPaths: [] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run(
+  "no-index with one of the paths containing a wrong glob pattern: [{ folderPaths: ['src/components/**', false]}]",
+  rule,
+  {
+    valid: [],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/index.jsx',
+        options: [{ folderPaths: ['src/components/**', false] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+          {
+            message:
+              'There is an invalid pattern "false", please double-check it and try again',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  "no-index with option [{ folderPaths: ['src/components/**'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/login.jsx',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/utils/calculatePrice.js',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/utils/index.config.js',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.config.ts',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/Breadcrumb/index.tsx',
+        options: [{ folderPaths: ['src/components/**'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/index.jsx',
+        options: [{ folderPaths: ['src/components/**'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  "no-index with option: [{ folderPaths: ['src/components/**'], ignoreMiddleExtensions: true }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/utils/index.config.js',
+        options: [
+          { folderPaths: ['src/components/**'], ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.config.ts',
+        options: [
+          { folderPaths: ['src/components/**'], ignoreMiddleExtensions: true },
+        ],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/index.config.js',
+        options: [
+          { folderPaths: ['src/components/**'], ignoreMiddleExtensions: true },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/config/index.config.js',
+        options: [
+          { folderPaths: ['src/components/**'], ignoreMiddleExtensions: true },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  "no-index with many options: [{ folderPaths: ['**/server/**', 'src/components/**', 'src/utils/*', '**/[[]*/'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/Breadcrumb/Breadcrumb.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'shared/components/index.js',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/utils/isValidEmail.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/validators/index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/utils/index.config.js',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/dashboard/[pageId]/Page.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'app/server/middleware.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/components/Breadcrumb/index.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/utils/dates/index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/dashboard/[pageId]/index.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'app/server/db/index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);

--- a/tests/lib/rules/no-index.windows.js
+++ b/tests/lib/rules/no-index.windows.js
@@ -131,3 +131,488 @@ ruleTester.run(
     ],
   }
 );
+
+ruleTester.run(
+  "no-index with option on Windows: [{ folderPaths: ['*'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\login.jsx',
+        options: [{ folderPaths: ['*'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\calculatePrice.js',
+        options: [{ folderPaths: ['*'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\index.config.js',
+        options: [{ folderPaths: ['*'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.config.js',
+        options: [{ folderPaths: ['*'] }],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\index.jsx',
+        options: [{ folderPaths: ['*'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\index.js',
+        options: [{ folderPaths: ['*'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.js',
+        options: [{ folderPaths: ['*'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run('no-index with option on Windows: [{ folderPaths: [] }]', rule, {
+  valid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src\\components\\login.jsx',
+      options: [{ folderPaths: [] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src\\utils\\calculatePrice.js',
+      options: [{ folderPaths: [] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src\\utils\\index.config.js',
+      options: [{ folderPaths: [] }],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'index.config.js',
+      options: [{ folderPaths: [] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "var foo = 'bar';",
+      filename: 'src\\components\\index.jsx',
+      options: [{ folderPaths: [] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'src\\utils\\index.js',
+      options: [{ folderPaths: [] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "var foo = 'bar';",
+      filename: 'index.js',
+      options: [{ folderPaths: [] }],
+      errors: [
+        {
+          message: 'The filename "index" is not allowed',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run(
+  "no-index with one of the paths containing a wrong glob pattern on Windows: [{ folderPaths: ['src/components/**', false]}]",
+  rule,
+  {
+    valid: [],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\index.jsx',
+        options: [{ folderPaths: ['src/components/**', false] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+          {
+            message:
+              'There is an invalid pattern "false", please double-check it and try again',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  "no-index with option on Windows: [{ folderPaths: ['src/components/**'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\login.jsx',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\calculatePrice.js',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\index.config.js',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.config.ts',
+        options: [{ folderPaths: ['src/components/**'] }],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\Breadcrumb\\index.tsx',
+        options: [{ folderPaths: ['src/components/**'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\index.jsx',
+        options: [{ folderPaths: ['src/components/**'] }],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  "no-index with option on Windows: [{ folderPaths: ['src/components/**'], ignoreMiddleExtensions: true }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\index.config.js',
+        options: [
+          {
+            folderPaths: ['src/components/**'],
+            ignoreMiddleExtensions: true,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.config.ts',
+        options: [
+          {
+            folderPaths: ['src/components/**'],
+            ignoreMiddleExtensions: true,
+          },
+        ],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\index.config.js',
+        options: [
+          {
+            folderPaths: ['src/components/**'],
+            ignoreMiddleExtensions: true,
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\config\\index.config.js',
+        options: [
+          {
+            folderPaths: ['src/components/**'],
+            ignoreMiddleExtensions: true,
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  "no-index with many options on Windows: [{ folderPaths: ['src/components/**', 'src/utils/*', '**/[[]*'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\Breadcrumb\\Breadcrumb.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'shared\\components\\index.js',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\isValidEmail.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\validators\\index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\index.config.js',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\dashboard\\[pageId]\\Page.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'app\\server\\middleware.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+      },
+    ],
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\components\\Breadcrumb\\index.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\utils\\dates\\index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\dashboard\\[pageId]\\index.tsx',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'app\\server\\db\\index.ts',
+        options: [
+          {
+            folderPaths: [
+              '**/server/**',
+              'src/components/**',
+              'src/utils/*',
+              '**/[[]*/',
+            ],
+          },
+        ],
+        errors: [
+          {
+            message: 'The filename "index" is not allowed',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);


### PR DESCRIPTION
Hi y'all, this pull request introduces a new feature to the `no-index` rule, allowing it to support multiple folder patterns. This enhancement enables users to define multiple glob patterns where the rule should be applied.

At my workplace, we have a specific use case where we need to limit the usage of the index filename based on specific folder patterns. This feature will help us enforce our coding standards more effectively by specifying where the index filename should be restricted. Please note that this PR isn't introducing any breaking changes to the `no-index` rule, so whoever is using this rule and opts to not pass a custom folder paths array, it'll be applied to the whole project. I also added more test cases to cover additional scenarios.

Usage example:

```
"check-file/no-index": [
      "error",
      ["app/server/**", "app/utils/**"]
],
```

I look forward to your feedback and hope this enhancement will be beneficial to others as well 😄 