### PR TITLE
feat: add support for css,json,markdown parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,15 @@ import checkFile from 'eslint-plugin-check-file';
 
 export default [
   {
+    // optional: add this processor to files which not processed by other processors
+    files: ['**/*.yaml', '**/*.webp', '**/.gitignore'],
+    processor: 'check-file/eslint-processor-check-file',
+  },
+  {
     files: ['src/**/*.*'],
     plugins: {
       'check-file': checkFile,
     },
-    // optional: add this processor if you want to lint non-js/ts files (images, styles, etc.)
-    processor: 'check-file/eslint-processor-check-file',
     rules: {
       'check-file/no-index': 'error',
       'check-file/filename-blocklist': [

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ const plugin = {
       postprocess(messages) {
         return [].concat(...messages);
       },
+      supportsAutofix: true,
     },
   },
 };

--- a/lib/rules/filename-blocklist.js
+++ b/lib/rules/filename-blocklist.js
@@ -51,59 +51,64 @@ export default {
   },
 
   create(context) {
-    return {
-      Program: (node) => {
-        const rules = context.options[0];
-        const errorMessage = context.options[1]?.errorMessage ?? '';
-        const error = validateNamingPatternObject(
-          rules,
-          globPatternValidator,
-          isEmpty(errorMessage) ? globPatternValidator : () => true
-        );
+    const rule = (node) => {
+      const rules = context.options[0];
+      const errorMessage = context.options[1]?.errorMessage ?? '';
+      const error = validateNamingPatternObject(
+        rules,
+        globPatternValidator,
+        isEmpty(errorMessage) ? globPatternValidator : () => true
+      );
 
-        if (error) {
-          context.report({
-            node,
-            messageId: error.type,
-            data: {
-              value: error.payload,
-            },
-          });
+      if (error) {
+        context.report({
+          node,
+          messageId: error.type,
+          data: {
+            value: error.payload,
+          },
+        });
+        return;
+      }
+
+      const filenameWithPath = getFilePath(context);
+      const filename = getFilename(filenameWithPath);
+
+      for (const [blockListPattern, useInsteadPattern] of Object.entries(
+        rules
+      )) {
+        const matchResult = matchRule(filenameWithPath, blockListPattern);
+
+        if (matchResult) {
+          isNotEmpty(errorMessage)
+            ? context.report({
+                node,
+                // eslint-disable-next-line eslint-plugin/prefer-message-ids
+                message: errorMessage,
+                data: {
+                  target: filename,
+                  pattern: blockListPattern,
+                },
+              })
+            : context.report({
+                node,
+                messageId: 'noMatch',
+                data: {
+                  filename,
+                  blockListPattern,
+                  suggestion: useInsteadPattern,
+                },
+              });
           return;
         }
+      }
+    };
 
-        const filenameWithPath = getFilePath(context);
-        const filename = getFilename(filenameWithPath);
-
-        for (const [blockListPattern, useInsteadPattern] of Object.entries(
-          rules
-        )) {
-          const matchResult = matchRule(filenameWithPath, blockListPattern);
-
-          if (matchResult) {
-            isNotEmpty(errorMessage)
-              ? context.report({
-                  node,
-                  // eslint-disable-next-line eslint-plugin/prefer-message-ids
-                  message: errorMessage,
-                  data: {
-                    target: filename,
-                    pattern: blockListPattern,
-                  },
-                })
-              : context.report({
-                  node,
-                  messageId: 'noMatch',
-                  data: {
-                    filename,
-                    blockListPattern,
-                    suggestion: useInsteadPattern,
-                  },
-                });
-            return;
-          }
-        }
-      },
+    return {
+      Document: rule,
+      Program: rule,
+      root: rule,
+      StyleSheet: rule,
     };
   },
 };

--- a/lib/rules/filename-naming-convention.js
+++ b/lib/rules/filename-naming-convention.js
@@ -59,80 +59,85 @@ export default {
   },
 
   create(context) {
-    return {
-      Program: (node) => {
-        const rules = context.options[0];
-        const error = validateNamingPatternObject(
-          rules,
-          globPatternValidator,
-          (p) =>
-            filenameNamingPatternValidator(p) ||
-            nextJsFilenameNamingPatternValidator(p)
-        );
+    const rule = (node) => {
+      const rules = context.options[0];
+      const error = validateNamingPatternObject(
+        rules,
+        globPatternValidator,
+        (p) =>
+          filenameNamingPatternValidator(p) ||
+          nextJsFilenameNamingPatternValidator(p)
+      );
 
-        if (error) {
-          context.report({
-            node,
-            messageId: error.type,
-            data: {
-              value: error.payload,
-            },
-          });
-          return;
-        }
+      if (error) {
+        context.report({
+          node,
+          messageId: error.type,
+          data: {
+            value: error.payload,
+          },
+        });
+        return;
+      }
 
-        const filenameWithPath = getFilePath(context);
-        const filename = getFilename(filenameWithPath);
-        const ignoreMiddleExtensions =
-          context.options[1]?.ignoreMiddleExtensions ?? false;
-        const errorMessage = context.options[1]?.errorMessage ?? '';
+      const filenameWithPath = getFilePath(context);
+      const filename = getFilename(filenameWithPath);
+      const ignoreMiddleExtensions =
+        context.options[1]?.ignoreMiddleExtensions ?? false;
+      const errorMessage = context.options[1]?.errorMessage ?? '';
 
-        for (const [
-          originalFilenamePattern,
-          originalNamingPattern,
-        ] of Object.entries(rules)) {
-          try {
-            const [filenamePattern, namingPattern] =
-              transformRuleWithPrefinedMatchSyntax(
-                [originalFilenamePattern, originalNamingPattern],
-                filenameWithPath
-              );
-
-            const matchResult = matchRule(
-              filenameWithPath,
-              filenamePattern,
-              getBasename(filename, ignoreMiddleExtensions),
-              namingPattern
+      for (const [
+        originalFilenamePattern,
+        originalNamingPattern,
+      ] of Object.entries(rules)) {
+        try {
+          const [filenamePattern, namingPattern] =
+            transformRuleWithPrefinedMatchSyntax(
+              [originalFilenamePattern, originalNamingPattern],
+              filenameWithPath
             );
 
-            if (matchResult) {
-              throw {
-                type: 'noMatch',
-                payload: {
-                  filename,
-                  originalNamingPattern,
-                },
-              };
-            }
-          } catch (error) {
-            isNotEmpty(errorMessage) && error.type === 'noMatch'
-              ? context.report({
-                  node,
-                  // eslint-disable-next-line eslint-plugin/prefer-message-ids
-                  message: errorMessage,
-                  data: {
-                    target: error.payload.filename,
-                    pattern: error.payload.originalNamingPattern,
-                  },
-                })
-              : context.report({
-                  node,
-                  messageId: error.type,
-                  data: error.payload,
-                });
+          const matchResult = matchRule(
+            filenameWithPath,
+            filenamePattern,
+            getBasename(filename, ignoreMiddleExtensions),
+            namingPattern
+          );
+
+          if (matchResult) {
+            throw {
+              type: 'noMatch',
+              payload: {
+                filename,
+                originalNamingPattern,
+              },
+            };
           }
+        } catch (error) {
+          isNotEmpty(errorMessage) && error.type === 'noMatch'
+            ? context.report({
+                node,
+                // eslint-disable-next-line eslint-plugin/prefer-message-ids
+                message: errorMessage,
+                data: {
+                  target: error.payload.filename,
+                  pattern: error.payload.originalNamingPattern,
+                },
+              })
+            : context.report({
+                node,
+                messageId: error.type,
+                data: error.payload,
+              });
         }
-      },
+      }
+    };
+
+    return {
+      Document: rule,
+      Program: rule,
+      root: rule,
+      StyleSheet: rule,
     };
   },
 };

--- a/lib/rules/folder-match-with-fex.js
+++ b/lib/rules/folder-match-with-fex.js
@@ -52,62 +52,67 @@ export default {
   },
 
   create(context) {
-    return {
-      Program: (node) => {
-        const rules = context.options[0];
-        const error = validateNamingPatternObject(
-          rules,
-          globPatternValidator,
-          globPatternValidator
+    const rule = (node) => {
+      const rules = context.options[0];
+      const error = validateNamingPatternObject(
+        rules,
+        globPatternValidator,
+        globPatternValidator
+      );
+
+      if (error) {
+        context.report({
+          node,
+          messageId: error.type,
+          data: {
+            value: error.payload,
+          },
+        });
+        return;
+      }
+
+      const filenameWithPath = getFilePath(context);
+      const filename = getFilename(filenameWithPath);
+      const folderPath = getFolderPath(filenameWithPath);
+      const errorMessage = context.options[1]?.errorMessage ?? '';
+
+      for (const [fexPattern, folderPattern] of Object.entries(rules)) {
+        const matchResult = matchRule(
+          filename,
+          fexPattern,
+          folderPath,
+          folderPattern
         );
 
-        if (error) {
-          context.report({
-            node,
-            messageId: error.type,
-            data: {
-              value: error.payload,
-            },
-          });
+        if (matchResult) {
+          isNotEmpty(errorMessage)
+            ? context.report({
+                node,
+                // eslint-disable-next-line eslint-plugin/prefer-message-ids
+                message: errorMessage,
+                data: {
+                  target: filename,
+                  pattern: folderPattern,
+                },
+              })
+            : context.report({
+                node,
+                messageId: 'noMatch',
+                data: {
+                  filename,
+                  folderPattern,
+                },
+              });
           return;
         }
+      }
+    };
 
-        const filenameWithPath = getFilePath(context);
-        const filename = getFilename(filenameWithPath);
-        const folderPath = getFolderPath(filenameWithPath);
-        const errorMessage = context.options[1]?.errorMessage ?? '';
-
-        for (const [fexPattern, folderPattern] of Object.entries(rules)) {
-          const matchResult = matchRule(
-            filename,
-            fexPattern,
-            folderPath,
-            folderPattern
-          );
-
-          if (matchResult) {
-            isNotEmpty(errorMessage)
-              ? context.report({
-                  node,
-                  // eslint-disable-next-line eslint-plugin/prefer-message-ids
-                  message: errorMessage,
-                  data: {
-                    target: filename,
-                    pattern: folderPattern,
-                  },
-                })
-              : context.report({
-                  node,
-                  messageId: 'noMatch',
-                  data: {
-                    filename,
-                    folderPattern,
-                  },
-                });
-            return;
-          }
-        }
-      },
+    return {
+      Document: rule,
+      Program: rule,
+      root: rule,
+      StyleSheet: rule,
     };
   },
 };

--- a/lib/rules/folder-naming-convention.js
+++ b/lib/rules/folder-naming-convention.js
@@ -59,80 +59,85 @@ export default {
   },
 
   create(context) {
-    return {
-      Program: (node) => {
-        const rules = context.options[0];
-        const error = validateNamingPatternObject(
-          rules,
-          globPatternValidator,
-          folderNamingPatternValidator
-        );
+    const rule = (node) => {
+      const rules = context.options[0];
+      const error = validateNamingPatternObject(
+        rules,
+        globPatternValidator,
+        folderNamingPatternValidator
+      );
 
-        if (error) {
-          context.report({
-            node,
-            messageId: error.type,
-            data: {
-              value: error.payload,
-            },
-          });
-          return;
+      if (error) {
+        context.report({
+          node,
+          messageId: error.type,
+          data: {
+            value: error.payload,
+          },
+        });
+        return;
+      }
+
+      const filenameWithPath = getFilePath(context);
+      const folderPath = getFolderPath(filenameWithPath);
+      const errorMessage = context.options[1]?.errorMessage ?? '';
+
+      for (const [folderPattern, namingPattern] of Object.entries(rules)) {
+        if (
+          !micromatch.isMatch(folderPath, folderPattern, { contains: true })
+        ) {
+          continue;
         }
+        for (const path of getSubPaths(folderPath)) {
+          const matchedPaths = micromatch.capture(folderPattern, path, {
+            dot: true,
+          });
 
-        const filenameWithPath = getFilePath(context);
-        const folderPath = getFolderPath(filenameWithPath);
-        const errorMessage = context.options[1]?.errorMessage ?? '';
+          if (isNil(matchedPaths)) continue;
 
-        for (const [folderPattern, namingPattern] of Object.entries(rules)) {
-          if (
-            !micromatch.isMatch(folderPath, folderPattern, { contains: true })
-          ) {
-            continue;
-          }
-          for (const path of getSubPaths(folderPath)) {
-            const matchedPaths = micromatch.capture(folderPattern, path, {
-              dot: true,
-            });
+          const folders = matchedPaths
+            .filter(isNotEmpty)
+            .reduce((s, p) => s.concat(getAllFolders(p)), []);
 
-            if (isNil(matchedPaths)) continue;
-
-            const folders = matchedPaths
-              .filter(isNotEmpty)
-              .reduce((s, p) => s.concat(getAllFolders(p)), []);
-
-            for (const folder of folders) {
-              if (
-                !micromatch.isMatch(
-                  folder,
-                  BASIC_NAMING_CONVENTION[namingPattern] ||
-                    NEXT_JS_NAMING_CONVENTION[namingPattern] ||
-                    namingPattern
-                )
-              ) {
-                isNotEmpty(errorMessage)
-                  ? context.report({
-                      node,
-                      // eslint-disable-next-line eslint-plugin/prefer-message-ids
-                      message: errorMessage,
-                      data: {
-                        target: folder,
-                        pattern: namingPattern,
-                      },
-                    })
-                  : context.report({
-                      node,
-                      messageId: 'noMatch',
-                      data: {
-                        folder,
-                        namingPattern,
-                      },
-                    });
-                return;
-              }
+          for (const folder of folders) {
+            if (
+              !micromatch.isMatch(
+                folder,
+                BASIC_NAMING_CONVENTION[namingPattern] ||
+                  NEXT_JS_NAMING_CONVENTION[namingPattern] ||
+                  namingPattern
+              )
+            ) {
+              isNotEmpty(errorMessage)
+                ? context.report({
+                    node,
+                    // eslint-disable-next-line eslint-plugin/prefer-message-ids
+                    message: errorMessage,
+                    data: {
+                      target: folder,
+                      pattern: namingPattern,
+                    },
+                  })
+                : context.report({
+                    node,
+                    messageId: 'noMatch',
+                    data: {
+                      folder,
+                      namingPattern,
+                    },
+                  });
+              return;
             }
           }
         }
-      },
+      }
+    };
+
+    return {
+      Document: rule,
+      Program: rule,
+      root: rule,
+      StyleSheet: rule,
     };
   },
 };

--- a/lib/rules/no-index.js
+++ b/lib/rules/no-index.js
@@ -36,32 +36,37 @@ export default {
   },
 
   create(context) {
-    return {
-      Program: (node) => {
-        const ignoreMiddleExtensions =
-          context.options[0]?.ignoreMiddleExtensions ?? false;
-        const errorMessage = context.options[0]?.errorMessage ?? '';
-        const filenameWithPath = getFilePath(context);
-        const filename = getFilename(filenameWithPath);
-        const basename = getBasename(filename, ignoreMiddleExtensions);
+    const rule = (node) => {
+      const ignoreMiddleExtensions =
+        context.options[0]?.ignoreMiddleExtensions ?? false;
+      const errorMessage = context.options[0]?.errorMessage ?? '';
+      const filenameWithPath = getFilePath(context);
+      const filename = getFilename(filenameWithPath);
+      const basename = getBasename(filename, ignoreMiddleExtensions);
 
-        if (basename === 'index') {
-          isNotEmpty(errorMessage)
-            ? context.report({
-                node,
-                // eslint-disable-next-line eslint-plugin/prefer-message-ids
-                message: errorMessage,
-                data: {
-                  target: filename,
-                },
-              })
-            : context.report({
-                node,
-                messageId: 'noIndex',
-              });
-          return;
-        }
-      },
+      if (basename === 'index') {
+        isNotEmpty(errorMessage)
+          ? context.report({
+              node,
+              // eslint-disable-next-line eslint-plugin/prefer-message-ids
+              message: errorMessage,
+              data: {
+                target: filename,
+              },
+            })
+          : context.report({
+              node,
+              messageId: 'noIndex',
+            });
+        return;
+      }
+    };
+
+    return {
+      Document: rule,
+      Program: rule,
+      root: rule,
+      StyleSheet: rule,
     };
   },
 };


### PR DESCRIPTION
ESLint officially supports linting of JSON, Markdown and CSS files.
This PR brings compatibility with currently existing parsers/plugins for these languages.
 