### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dukeluo/eslint-plugin-check-file/security/code-scanning/2](https://github.com/dukeluo/eslint-plugin-check-file/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs by default. This ensures that the `build` job, which does not require any write permissions, operates with the least privilege. The `publish-npm` job already has a specific `permissions` block, so it will override the root-level permissions as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
