### PR TITLE
fix: ignore dots inside brackets when extracting basename

### DIFF
--- a/lib/utils/filename.js
+++ b/lib/utils/filename.js
@@ -24,11 +24,33 @@ export const getFolderPath = (p) => posix.join(posix.dirname(p), posix.sep);
  * @param {string} filename filename without path
  * @param {boolean} [ignoreMiddleExtensions] flag to ignore middle extensions
  */
-export const getBasename = (filename, ignoreMiddleExtensions = false) =>
-  filename.substring(
-    0,
-    ignoreMiddleExtensions ? filename.indexOf('.') : filename.lastIndexOf('.')
-  );
+export const getBasename = (filename, ignoreMiddleExtensions = false) => {
+  const findDotsOutsideBrackets = (str) => {
+    const positions = [];
+    let depth = 0;
+
+    for (let i = 0; i < str.length; i++) {
+      if (str[i] === '[') depth++;
+      else if (str[i] === ']') depth--;
+      else if (str[i] === '.' && depth === 0) {
+        positions.push(i);
+      }
+    }
+    return positions;
+  };
+
+  const dotPositions = findDotsOutsideBrackets(filename);
+
+  if (dotPositions.length === 0) {
+    return filename;
+  }
+
+  const curPosition = ignoreMiddleExtensions
+    ? dotPositions[0]
+    : dotPositions[dotPositions.length - 1];
+
+  return filename.substring(0, curPosition);
+};
 
 /**
  * @returns {string[]} all folders

--- a/tests/lib/rules/filename-naming-convention.posix.js
+++ b/tests/lib/rules/filename-naming-convention.posix.js
@@ -805,6 +805,82 @@ ruleTester.run(
 );
 
 ruleTester.run(
+  "filename-naming-convention with Next.js dynamic routes and option: [{ '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' }, { ignoreMiddleExtensions: true }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/blog/[[...userId]].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/blog/[[...slug]].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/blog/[...params].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/user/[id].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/post/[postId].test.tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/api/user.test.ts',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+    ],
+
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/pages/blog/Invalid_Name.tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+        errors: [
+          {
+            message:
+              'The filename "Invalid_Name.tsx" does not match the "NEXT_JS_PAGE_ROUTER_FILENAME_CASE" pattern',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
   "filename-naming-convention with option: [{ '**/*.js': '__+([a-z])', '**/*.jsx': '__+([a-z])' }]",
   rule,
   {

--- a/tests/lib/rules/filename-naming-convention.windows.js
+++ b/tests/lib/rules/filename-naming-convention.windows.js
@@ -827,6 +827,82 @@ ruleTester.run(
 );
 
 ruleTester.run(
+  "filename-naming-convention with Next.js dynamic routes and option on Windows: [{ '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' }, { ignoreMiddleExtensions: true }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\blog\\[[...userId]].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\blog\\[[...slug]].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\blog\\[...params].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\user\\[id].tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\post\\[postId].test.tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\api\\user.test.ts',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+      },
+    ],
+
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\pages\\blog\\Invalid_Name.tsx',
+        options: [
+          { '**/*.{js,jsx,ts,tsx}': 'NEXT_JS_PAGE_ROUTER_FILENAME_CASE' },
+          { ignoreMiddleExtensions: true },
+        ],
+        errors: [
+          {
+            message:
+              'The filename "Invalid_Name.tsx" does not match the "NEXT_JS_PAGE_ROUTER_FILENAME_CASE" pattern',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
   "filename-naming-convention with option on Windows: [{ '**/*.js': 'CAMEL_CASE' }, { ignoreMiddleExtensions: true }]",
   rule,
   {


### PR DESCRIPTION
## Description

This PR fixes the `getBasename` function to properly handle dots inside brackets (e.g., `[...]`) when extracting the base filename. Previously, dots inside brackets were incorrectly treated as extension separators.

## Problem

When processing filenames with brackets containing dots (e.g., Next.js dynamic routes like `[[...slug]].tsx`), the `getBasename` function would incorrectly identify dots inside brackets as extension delimiters.

**Example:**
- Before: `getBasename('[[...slug]].tsx')` would incorrectly split at the first dot inside brackets
- After: `getBasename('[[...slug]].tsx')` correctly returns `'[[...slug]]'`

## Solution

Modified the `getBasename` function to:
1. Track bracket depth while scanning the filename
2. Only consider dots that are outside of bracket pairs as extension separators
3. Return the full filename if no dots exist outside brackets

## Changes

### Core Changes
- **`lib/utils/filename.js`**: Refactored `getBasename` to skip dots inside brackets
  - Added `findDotsOutsideBrackets` helper function
  - Maintains bracket depth tracking
  - Only treats dots at depth 0 as extension separators