### PR TITLE
fix: update nextjs named slots to camel case

### DIFF
--- a/lib/constants/next-js-naming-convention.js
+++ b/lib/constants/next-js-naming-convention.js
@@ -26,9 +26,9 @@ const NEXT_JS_OPTIONAL_CATCH_ALL_SEGMENTS = `\\[\\[...${CAMEL_CASE}\\]\\]`;
 const NEXT_JS_ROUTE_GROUPS = `\\(${KEBAB_CASE}\\)`;
 
 /**
- * @example \@feed
+ * @example \@feed, \@analytics, \@teamSettings, \@userDashboard
  */
-const NEXT_JS_NAMED_SLOTS = `\\@${KEBAB_CASE}`;
+const NEXT_JS_NAMED_SLOTS = `\\@${CAMEL_CASE}`;
 
 /**
  * @example \_components
@@ -41,7 +41,7 @@ const NEXT_JS_PRIVATE_FOLDERS = `\\_${KEBAB_CASE}`;
 const NEXT_JS_FILENAME_ROUTE = `+([a-z])?(.+([a-z]))`;
 
 /**
- * @example app, [helpPageId], [...auth], [[...auth]], (auth), \@feed
+ * @example app, [helpPageId], [...auth], [[...auth]], (auth), \@feed, \@teamSettings
  */
 export const NEXT_JS_APP_ROUTER_CASE = `@(${KEBAB_CASE}|${NEXT_JS_FILENAME_ROUTE}|${NEXT_JS_DYNAMIC_SEGMENTS}|${NEXT_JS_CATCH_ALL_SEGMENTS}|${NEXT_JS_OPTIONAL_CATCH_ALL_SEGMENTS}|${NEXT_JS_ROUTE_GROUPS}|${NEXT_JS_NAMED_SLOTS}|${NEXT_JS_PRIVATE_FOLDERS})`;
 

--- a/tests/lib/rules/folder-naming-convention.posix.js
+++ b/tests/lib/rules/folder-naming-convention.posix.js
@@ -429,6 +429,16 @@ ruleTester.run(
       },
       {
         code: "var foo = 'bar';",
+        filename: 'src/app/@teamSettings/page.ts',
+        options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/app/@userDashboard/page.ts',
+        options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
+      },
+      {
+        code: "var foo = 'bar';",
         filename: 'src/app/(marketing)/page.ts',
         options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
       },
@@ -564,12 +574,25 @@ ruleTester.run(
       },
       {
         code: "var foo = 'bar';",
-        filename: 'src/app/@authMarker/page.ts',
+        filename: 'src/app/@AuthMarker/page.ts',
         options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
         errors: [
           {
             message:
-              'The folder "@authMarker" does not match the "NEXT_JS_APP_ROUTER_CASE" pattern',
+              'The folder "@AuthMarker" does not match the "NEXT_JS_APP_ROUTER_CASE" pattern',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src/app/@team-settings/page.ts',
+        options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
+        errors: [
+          {
+            message:
+              'The folder "@team-settings" does not match the "NEXT_JS_APP_ROUTER_CASE" pattern',
             column: 1,
             line: 1,
           },

--- a/tests/lib/rules/folder-naming-convention.windows.js
+++ b/tests/lib/rules/folder-naming-convention.windows.js
@@ -432,6 +432,16 @@ ruleTester.run(
       },
       {
         code: "var foo = 'bar';",
+        filename: 'src\\app\\@teamSettings\\page.ts',
+        options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\app\\@userDashboard\\page.ts',
+        options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
+      },
+      {
+        code: "var foo = 'bar';",
         filename: 'src\\app\\(marketing)\\page.ts',
         options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
       },
@@ -567,12 +577,25 @@ ruleTester.run(
       },
       {
         code: "var foo = 'bar';",
-        filename: 'src\\app\\@authMarker\\page.ts',
+        filename: 'src\\app\\@AuthMarker\\page.ts',
         options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
         errors: [
           {
             message:
-              'The folder "@authMarker" does not match the "NEXT_JS_APP_ROUTER_CASE" pattern',
+              'The folder "@AuthMarker" does not match the "NEXT_JS_APP_ROUTER_CASE" pattern',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'src\\app\\@team-settings\\page.ts',
+        options: [{ 'src/**/': 'NEXT_JS_APP_ROUTER_CASE' }],
+        errors: [
+          {
+            message:
+              'The folder "@team-settings" does not match the "NEXT_JS_APP_ROUTER_CASE" pattern',
             column: 1,
             line: 1,
           },


### PR DESCRIPTION
From what I've researched, Next.js App Router slots are best supported as camel-cased. There are a handful of PRs open on the Next.js repo asking for support of kebab-cased slots, but camel-cased slots is a hacky workaround currently.

Related Next.js PRS:
- https://github.com/vercel/next.js/issues/56330
- https://github.com/vercel/next.js/pull/74242